### PR TITLE
Implement contains? for Rectangle

### DIFF
--- a/demos/test/geo_test.rb
+++ b/demos/test/geo_test.rb
@@ -17,4 +17,24 @@ class GeoTest < Minitest::Test
 
     assert(rectangle.contains?(middle))
   end
+
+  def test_rectangle_contains_edge
+    top_left = Point.new(0.0, 10.0)
+    bottom_right = Point.new(10.0, 0.0)
+    point1 = Point.new(10.0, 5.0)
+    point2 = Point.new(5.0, 10.0)
+    rectangle = Rectangle.new(top_left, bottom_right)
+
+    assert(rectangle.contains?(point1))
+    assert(rectangle.contains?(point2))
+  end
+
+  def test_rectangle_not_contains
+    top_left = Point.new(0.0, 10.0)
+    right_left = Point.new(10.0, 0.0)
+    outside = Point.new(100.0, 100.0)
+    rectangle = Rectangle.new(top_left, right_left)
+
+    refute(rectangle.contains?(outside))
+  end
 end


### PR DESCRIPTION
Implemented the `contains?` method for `Rectangle` using two different approaches. 

First the simple algorithm:
- Check that the point M's x are between the `top_left` and `bottom_right`'s x-values
- Check that the point M's y are between the `top_left` and `bottom_right`'s y-values
- If both are satisfied, M is within the Rectangle

The more generic approach:
- Calculate a third point (this could be given in the future, to account for non-regular rectangles)
- Use the formula: 
  - `0 <= dot(AB, AM) <= dot(AB, AB) && 0 <= dot(BC, BM) <= dot(BC, BC)`

This also exposes the new `dot` method to Ruby.